### PR TITLE
Fetch apt keys over https

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,9 @@ echo "under certain conditions.  read this script for details."
 
 # install the repository signing keys used for packages.hedgerows.org.uk
 # - for jon@hedgerows.org.uk
-wget -qO - "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8B07C4FF0F5BFDFE" | sudo apt-key add -
+wget -qO - "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8B07C4FF0F5BFDFE" | sudo apt-key add -
 # - for jon's build-bot
-wget -qO - "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0315CB6C13924333" | sudo apt-key add -
+wget -qO - "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0315CB6C13924333" | sudo apt-key add -
 
 # add the packages.hedgerows.org.uk repository
 echo "deb http://packages.hedgerows.org.uk/raspbian stable/" | sudo tee /etc/apt/sources.list.d/packages.hedgerows.org.uk.list


### PR DESCRIPTION
I was attempting to add your raspbian repo to my apt sources and wanted to find an initial point of trust - I noticed your apt signing keys are fetched over http, and wanted to be sure they weren't modified in transit. I found the github repo and so that became my initial point of trust, and following on from that, I can trust the key mentioned in [install.sh](./install.sh) (`0x8B07C4FF0F5BFDFE`) is yours and so if I can retrieve that key securely, I can then begin to use your repo.

This PR just adds a link in that chain, and defaults to https for future users. Thanks for your work maintaining get_iplayer!